### PR TITLE
Fix loading change resources in EMF solution template

### DIFF
--- a/solutions/EMFSolutionTemplate/src/ttc2018/LiveContestDriver.java
+++ b/solutions/EMFSolutionTemplate/src/ttc2018/LiveContestDriver.java
@@ -1,5 +1,8 @@
 package ttc2018;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -44,12 +47,12 @@ public class LiveContestDriver {
 
     private static Solution solution;
 
-    private static Object loadFile(String path) {
-    	Resource mRes = repository.getResource(URI.createFileURI(ChangePath + "/" + path), true);
+    private static Object loadFile(String path) throws IOException {
+    	Resource mRes = repository.getResource(URI.createFileURI(new File(ChangePath + "/" + path).getCanonicalPath()), true);
     	return mRes.getContents().get(0);
     }
 
-    static void Load()
+    static void Load() throws IOException
     {
     	stopwatch = System.nanoTime();
         solution.setSocialNetwork((SocialNetworkRoot)loadFile("initial.xmi"));
@@ -98,7 +101,7 @@ public class LiveContestDriver {
         Report(BenchmarkPhase.Initial, -1, result);
     }
 
-    static void Update(int iteration)
+    static void Update(int iteration) throws IOException
     {
         ModelChangeSet changes = (ModelChangeSet)loadFile(String.format("change%02d.xmi", iteration));
         stopwatch = System.nanoTime();


### PR DESCRIPTION
Running the vanilla `EMFSolutionTemplate` project results in the following exception:
```
EMFSolutionTemplate;Q1;1;Debug;0;Initialization;Time;422466095
EMFSolutionTemplate;Q1;1;Debug;0;Initialization;Memory;4901000
EMFSolutionTemplate;Q1;1;Debug;0;Load;Time;898040336
EMFSolutionTemplate;Q1;1;Debug;0;Load;Memory;3415304
EMFSolutionTemplate;Q1;1;Debug;0;Initial;Time;5183
EMFSolutionTemplate;Q1;1;Debug;0;Initial;Memory;3412376
org.eclipse.emf.common.util.AbstractEList$BasicIndexOutOfBoundsException: index=6, size=0
	at org.eclipse.emf.common.util.AbstractEList.add(AbstractEList.java:333)
	at Changes.impl.CompositionListInsertionImpl.apply(CompositionListInsertionImpl.java:247)
	at Changes.impl.ChangeTransactionImpl.apply(ChangeTransactionImpl.java:221)
	at ttc2018.SolutionQ1.Update(SolutionQ1.java:20)
	at ttc2018.LiveContestDriver.Update(LiveContestDriver.java:105)
	at ttc2018.LiveContestDriver.main(LiveContestDriver.java:26)
```

This exception was amended in tool-specific implementations such as `EMFSolutionXtend` but was not backported to the template. This PR implements the backport.
Please let me know if you suggested changes. The implementation throws exceptions instead of catching them - I prefer the "crash early" approach in benchmark code.