### PR TITLE
check result should give a warning if the expected result is not available

### DIFF
--- a/reporting/check_results.R
+++ b/reporting/check_results.R
@@ -13,8 +13,12 @@ for (tool in tools) {
       query.row = query_data[i,]
       expected.row = subset(expected, ChangeSet==query.row$ChangeSet & View==query & Iteration==query.row$Iteration)
       
-      if (as.character(query.row$MetricValue) != as.character(expected.row$MetricValue)) {
-        print(paste(tool, "is wrong. Was ", query.row$MetricValue, "but expected", expected.row$MetricValue, "for change set", query.row$ChangeSet, "query", query, "iteration", query.row$Iteration))
+      if (length(as.character(expected.row$MetricValue)) > 0) {
+        if (as.character(query.row$MetricValue) != as.character(expected.row$MetricValue)) {
+          print(paste(tool, "is wrong. Was ", query.row$MetricValue, "but expected", expected.row$MetricValue, "for change set", query.row$ChangeSet, "query", query, "iteration", query.row$Iteration))
+        }
+      } else {
+        print(paste("Warning:", tool, "produced the result", query.row$MetricValue, "but expected result is unavailable for change set", query.row$ChangeSet, "query", query, "iteration", query.row$Iteration))
       }
     }
   }


### PR DESCRIPTION
When experimenting with model size of 1024, check result halted with the error below because the expected results were unavailable:

```
Error in if (as.character(query.row$MetricValue) != as.character(expected.row$MetricValue)) { : 
  argument is of length zero
Execution halted
```

With this patch, a warning is output like:

> "Warning: FooSolution produced the result bar1|bar2|bar3 but expected result is unavailable for change set 1024 query Q1 iteration 17"