### PR TITLE
Adding README for JastAdd solutions pointing to separate repository.

### DIFF
--- a/solutions/jastadd-ttc18-relast-xml-flush/README.md
+++ b/solutions/jastadd-ttc18-relast-xml-flush/README.md
@@ -1,0 +1,1 @@
+The sources for all JastAdd solutions can be found in a [seperate repository](https://git-st.inf.tu-dresden.de/stgroup/ttc18live).

--- a/solutions/jastadd-ttc18-relast-xml-inc/README.md
+++ b/solutions/jastadd-ttc18-relast-xml-inc/README.md
@@ -1,0 +1,1 @@
+The sources for all JastAdd solutions can be found in a [seperate repository](https://git-st.inf.tu-dresden.de/stgroup/ttc18live).

--- a/solutions/jastadd-ttc18-xml-flush/README.md
+++ b/solutions/jastadd-ttc18-xml-flush/README.md
@@ -1,0 +1,1 @@
+The sources for all JastAdd solutions can be found in a [seperate repository](https://git-st.inf.tu-dresden.de/stgroup/ttc18live).

--- a/solutions/jastadd-ttc18-xml-inc/README.md
+++ b/solutions/jastadd-ttc18-xml-inc/README.md
@@ -1,0 +1,1 @@
+The sources for all JastAdd solutions can be found in a [seperate repository](https://git-st.inf.tu-dresden.de/stgroup/ttc18live).


### PR DESCRIPTION
As suggested in https://github.com/TransformationToolContest/ttc2018liveContest/pull/26#issuecomment-483232098, put in a README in the JastAdd solutions pointing to https://git-st.inf.tu-dresden.de/stgroup/ttc18live