### PR TITLE
Add timeout handling to the benchmark framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `docs/2018_TTC_Live.pdf` file contains the [case description](https://github
 ## Prerequisites
 
 * 64-bit operating system
-* Python 2.7 or higher
+* Python 3.3 or higher
 * R
 
 ## Solution Prerequisites
@@ -32,6 +32,8 @@ One might fine tune the script for the following purposes:
 
 The `config` directory contains the configuration for the scripts:
 * `config.json` -- configuration for the model generation and the benchmark
+  * *Note:* the timeout as set in the benchmark configuration (default: 6000 seconds) applies to the gross cumulative runtime of the tool for a given changeset and update sequences. This also includes e.g. Initialization time which is not required by the benchmark framework to be measured.
+    Timeout is only applied to the solutions' run phase (see `-m` for `run.py`), so it is not applied to e.g. the build phase (see `-b` for `run.py`).
 * `reporting.json` -- configuration for the visualization
 
 ### Running the benchmark

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 """
 @author: Zsolt Kovari, Georg Hinkel
 
@@ -64,11 +64,13 @@ def benchmark(conf):
                     print("Running benchmark: tool = " + tool + ", change set = " + change_set +
                           ", query = " + query)
                     try:
-                        output = subprocess.check_output(config.get('run', query), shell=True)
+                        output = subprocess.check_output(config.get('run', query), shell=True, timeout=conf.Timeout)
                         with open(result_file, "ab") as file:
                             file.write(output)
                     except CalledProcessError as e:
                         print("Program exited with error")
+                    except subprocess.TimeoutExpired as e:
+                        print("Program reached the timeout set ({0} seconds). The command we executed was '{1}'".format(e.timeout, e.cmd))
 
 
 def clean_dir(*path):


### PR DESCRIPTION
Note: this bumps Python version requirement to 3.3, and the timeout also includes the time the solution takes to initialize.

Build time as done during `run.py -b` is not affected by the timeout settings.