### PR TITLE
Fix case of default tool name

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,7 @@
     "Q1",
     "Q2"
   ],
-  "Tools": ["EMFSolutionYAMTL", "EMFSolutionYAMTL_Batch"],
+  "Tools": ["EMFSolutionYAMTL", "EMFSolutionYAMTL_batch"],
   "ChangeSets": [
     "1", "2", "4", "8", "16", "32", "64"
   ],


### PR DESCRIPTION
Failed on Linux due to the case sensitive file system.