### PR TITLE
Bump Xtend version

### DIFF
--- a/solutions/EMFSolutionXtend/build.gradle
+++ b/solutions/EMFSolutionXtend/build.gradle
@@ -17,15 +17,15 @@ dependencies {
 //	compile 'org.eclipse.emf:org.eclipse.emf.ecore.xmi:2.15.0'
 //	compile 'org.eclipse.emf:org.eclipse.emf.common:2.15.0'
 
-	compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.12.0'
-	compile 'org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.12.0'
+	compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.20.0'
+	compile 'org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.20.0'
 }
 
 apply plugin: 'eclipse'
 apply plugin: 'java'
 apply plugin: 'application'
 
-xtext.version = "2.12.0"
+xtext.version = "2.20.0"
 
 
 apply plugin: 'java-library-distribution'


### PR DESCRIPTION
Tried and tested:

```
$ cat config/config.json 
{
  "Queries": [
    "Q1",
    "Q2"
  ],
  "Tools": ["EMFSolutionXtend"],
  "ChangeSets": [
    "1"
  ],
  "Sequences": 20,
  "Runs": 5,
  "Timeout": 6000
}
$ scripts/run.py 
Running benchmark with root directory /home/szarnyasg/git/ttc/ttc2018liveContest
Running benchmark: tool = EMFSolutionXtend, change set = 1, query = Q1
Running benchmark: tool = EMFSolutionXtend, change set = 1, query = Q2
```