### PR TITLE
Change hawk git URL

### DIFF
--- a/solutions/Hawk/install-hawk-deps.sh
+++ b/solutions/Hawk/install-hawk-deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if ! test -d hawk; then
-  git clone -b v1.2.0-rc1 --depth 1 git://git.eclipse.org/gitroot/hawk/hawk.git
+  git clone -b v1.2.0-rc1 --depth 1 https://git.eclipse.org/r/hawk/hawk.git
 fi
 cd hawk
 mvn -B --quiet -f pom-plain.xml install -DskipTests


### PR DESCRIPTION
The transport protocol is changed from git:// to https:// as the the original URL returned an error thus breaking the build.

The error message returned was:
```
$ git clone -b v1.2.0-rc1 --depth 1 git://git.eclipse.org/gitroot/hawk/hawk.git
Cloning into 'hawk'...
fatal: remote error: access denied or repository not exported: /gitroot/hawk/hawk.git
```