### PR TITLE
Remove post from ecore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,3 +44,5 @@ changes/1024/
 *.swp
 .Rproj.user
 **/*.class
+.idea/
+**/*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ changes/1024/
 *.swp
 .Rproj.user
 **/*.class
+
+# IntelliJ
+.idea/
+*.iml

--- a/metamodels/social_network.ecore
+++ b/metamodels/social_network.ecore
@@ -21,8 +21,6 @@
         unique="false" lowerBound="1" eType="#//Submission" changeable="false" eOpposite="#//Submission/comments"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="likedBy" ordered="false"
         upperBound="-1" eType="#//User" eOpposite="#//User/likes"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="post" ordered="false" unique="false"
-        lowerBound="1" eType="#//Post"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="User">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" ordered="false" unique="false"

--- a/solutions/EMFSolutionYAMTL_batch/model/social_network.ecore
+++ b/solutions/EMFSolutionYAMTL_batch/model/social_network.ecore
@@ -21,8 +21,6 @@
         unique="false" lowerBound="1" eType="#//Submission" changeable="false" eOpposite="#//Submission/comments"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="likedBy" ordered="false"
         upperBound="-1" eType="#//User" eOpposite="#//User/likes"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="post" ordered="false" unique="false"
-        lowerBound="1" eType="#//Post"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="User">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" ordered="false" unique="false"

--- a/solutions/Hawk/org.hawk.ttc2018/models/social_network.genmodel
+++ b/solutions/Hawk/org.hawk.ttc2018/models/social_network.genmodel
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
-    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/EMFSolutionTemplate/src" modelPluginID="EMFSolutionTemplate"
+    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.hawk.ttc2018/src-gen" modelPluginID="org.hawk.ttc2018"
     modelName="Social_network" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
     importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false"
     operationReflection="true" importOrganizing="true">

--- a/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/Comment.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/Comment.java
@@ -26,10 +26,6 @@ public interface Comment extends Submission {
 	 * Returns the value of the '<em><b>Commented</b></em>' container reference.
 	 * It is bidirectional and its opposite is '{@link SocialNetwork.Submission#getComments <em>Comments</em>}'.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Commented</em>' container reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Commented</em>' container reference.
 	 * @see SocialNetwork.SocialNetworkPackage#getComment_Commented()
@@ -44,10 +40,6 @@ public interface Comment extends Submission {
 	 * The list contents are of type {@link SocialNetwork.User}.
 	 * It is bidirectional and its opposite is '{@link SocialNetwork.User#getLikes <em>Likes</em>}'.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Liked By</em>' reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Liked By</em>' reference list.
 	 * @see SocialNetwork.SocialNetworkPackage#getComment_LikedBy()

--- a/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/SocialNetworkRoot.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/SocialNetworkRoot.java
@@ -28,10 +28,6 @@ public interface SocialNetworkRoot extends EObject {
 	 * Returns the value of the '<em><b>Posts</b></em>' containment reference list.
 	 * The list contents are of type {@link SocialNetwork.Post}.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Posts</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Posts</em>' containment reference list.
 	 * @see SocialNetwork.SocialNetworkPackage#getSocialNetworkRoot_Posts()
@@ -44,10 +40,6 @@ public interface SocialNetworkRoot extends EObject {
 	 * Returns the value of the '<em><b>Users</b></em>' containment reference list.
 	 * The list contents are of type {@link SocialNetwork.User}.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Users</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Users</em>' containment reference list.
 	 * @see SocialNetwork.SocialNetworkPackage#getSocialNetworkRoot_Users()

--- a/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/Submission.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/Submission.java
@@ -32,10 +32,6 @@ public interface Submission extends EObject {
 	/**
 	 * Returns the value of the '<em><b>Id</b></em>' attribute.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Id</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Id</em>' attribute.
 	 * @see #setId(String)
@@ -58,10 +54,6 @@ public interface Submission extends EObject {
 	/**
 	 * Returns the value of the '<em><b>Timestamp</b></em>' attribute.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Timestamp</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Timestamp</em>' attribute.
 	 * @see #setTimestamp(Date)
@@ -84,10 +76,6 @@ public interface Submission extends EObject {
 	/**
 	 * Returns the value of the '<em><b>Content</b></em>' attribute.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Content</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Content</em>' attribute.
 	 * @see #setContent(String)
@@ -111,10 +99,6 @@ public interface Submission extends EObject {
 	 * Returns the value of the '<em><b>Submitter</b></em>' reference.
 	 * It is bidirectional and its opposite is '{@link SocialNetwork.User#getSubmissions <em>Submissions</em>}'.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Submitter</em>' reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Submitter</em>' reference.
 	 * @see #setSubmitter(User)
@@ -140,10 +124,6 @@ public interface Submission extends EObject {
 	 * The list contents are of type {@link SocialNetwork.Comment}.
 	 * It is bidirectional and its opposite is '{@link SocialNetwork.Comment#getCommented <em>Commented</em>}'.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Comments</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Comments</em>' containment reference list.
 	 * @see SocialNetwork.SocialNetworkPackage#getSubmission_Comments()

--- a/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/User.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/User.java
@@ -30,10 +30,6 @@ public interface User extends EObject {
 	/**
 	 * Returns the value of the '<em><b>Id</b></em>' attribute.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Id</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Id</em>' attribute.
 	 * @see #setId(String)
@@ -56,10 +52,6 @@ public interface User extends EObject {
 	/**
 	 * Returns the value of the '<em><b>Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Name</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Name</em>' attribute.
 	 * @see #setName(String)
@@ -84,10 +76,6 @@ public interface User extends EObject {
 	 * The list contents are of type {@link SocialNetwork.Submission}.
 	 * It is bidirectional and its opposite is '{@link SocialNetwork.Submission#getSubmitter <em>Submitter</em>}'.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Submissions</em>' reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Submissions</em>' reference list.
 	 * @see SocialNetwork.SocialNetworkPackage#getUser_Submissions()
@@ -102,10 +90,6 @@ public interface User extends EObject {
 	 * The list contents are of type {@link SocialNetwork.Comment}.
 	 * It is bidirectional and its opposite is '{@link SocialNetwork.Comment#getLikedBy <em>Liked By</em>}'.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Likes</em>' reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Likes</em>' reference list.
 	 * @see SocialNetwork.SocialNetworkPackage#getUser_Likes()
@@ -119,10 +103,6 @@ public interface User extends EObject {
 	 * Returns the value of the '<em><b>Friends</b></em>' reference list.
 	 * The list contents are of type {@link SocialNetwork.User}.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Friends</em>' reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Friends</em>' reference list.
 	 * @see SocialNetwork.SocialNetworkPackage#getUser_Friends()

--- a/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/impl/CommentImpl.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src-gen/SocialNetwork/impl/CommentImpl.java
@@ -8,12 +8,14 @@ import SocialNetwork.Submission;
 import SocialNetwork.User;
 
 import java.util.Collection;
+
 import org.eclipse.emf.common.notify.NotificationChain;
 
 import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
+
 import org.eclipse.emf.ecore.util.EObjectWithInverseResolvingEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/metamodels/social_network.ecore
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/metamodels/social_network.ecore
@@ -21,8 +21,6 @@
         unique="false" lowerBound="1" eType="#//Submission" changeable="false" eOpposite="#//Submission/comments"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="likedBy" ordered="false"
         upperBound="-1" eType="#//User" eOpposite="#//User/likes"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="post" ordered="false" unique="false"
-        lowerBound="1" eType="#//Post"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="User">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" ordered="false" unique="false"


### PR DESCRIPTION
The branch that removed the "post" reference from the metamodel did not update the main metamodels/social_network.ecore and did not update the generated code in the various solutions, breaking some of them (e.g. Hawk, which registers metamodels using the .ecore files).

Hopefully, this branch should fix those issues. I have only done it for Hawk: if that fixes the issue, perhaps the rest of the copies of social_network.ecore should be updated as well.