### PR TITLE
Disable building common base image in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
           sed -i s/--release// solutions/differential*/solution.ini
           sed -i "s|/release/|/debug/|" solutions/differential*/solution.ini
           ./docker.sh --pull                  # pull available images
-          ./docker.sh --build --tags common   # overwrite common base image for newly built images TODO: remove after the dataset is stable
           ./docker.sh --build-if-not-fresh    # (re)build image if different than current commit
           docker/set-configs.sh               # copy generic settings from config.json to config-docker-*.json files
           ./docker.sh -r --java-heap-size 6G  # run measurements


### PR DESCRIPTION
Turning off building `common` base image in CI to speed it up if the dataset is stable and uploaded to Docker Hub.
#85

This reverts commit abec6160bc4bd2d8973d3f55c8804a95d0b617b6.