### PR TITLE
SQL solution: remove using rootpost from Q1

### DIFF
--- a/solutions/SQLSolution/load-scripts/schema.sql
+++ b/solutions/SQLSolution/load-scripts/schema.sql
@@ -27,6 +27,8 @@ create table posts_d partition of posts for values in ('D');
 create table comments (
   like posts including all
 , parentid bigint not null
+-- postid refers to the root post of the comment and is populated and used only in the incremental solution
+, postid bigint
 ) partition by list (status);
 
 create table comments_i partition of comments for values in ('I');

--- a/solutions/SQLSolution/q1-rootpost-init.sql
+++ b/solutions/SQLSolution/q1-rootpost-init.sql
@@ -1,0 +1,26 @@
+WITH RECURSIVE
+  -- calculate ancestors of comments
+  comments_with_rootpost_stage1(id, ancestorid) AS (
+     SELECT c.id, c.parentid AS ancestorid
+       FROM comments c
+   UNION
+     SELECT cr.id, c.parentid AS ancestorid
+       FROM comments_with_rootpost_stage1 cr
+          , comments c
+      WHERE 1=1
+         -- join
+        AND cr.ancestorid = c.id
+  )
+  -- calculate rootpost: when ancestor's id matches a post's id, then it is the root post
+, comments_with_rootpost AS (
+    SELECT c.id, c.ancestorid AS postid
+      FROM comments_with_rootpost_stage1 c
+         , posts p
+     WHERE 1=1
+       AND c.ancestorid = p.id
+)
+UPDATE comments c
+   SET postid = cr.postid
+  FROM comments_with_rootpost cr
+ WHERE c.id = cr.id
+;

--- a/solutions/SQLSolution/q1-rootpost-maintain.sql
+++ b/solutions/SQLSolution/q1-rootpost-maintain.sql
@@ -1,0 +1,29 @@
+WITH RECURSIVE
+  -- calculate ancestors of new comments
+  comments_with_rootpost_stage1(id, ancestorid) AS (
+     SELECT c.id, c.parentid AS ancestorid
+       FROM comments_d c
+   UNION
+     SELECT cr.id
+            -- when we reach a comment for which the root post is known,
+            -- we jump directly to that without traversing the whole comment tree
+          , coalesce(c.postid, c.parentid) AS ancestorid
+       FROM comments_with_rootpost_stage1 cr
+          , comments c
+      WHERE 1=1
+         -- join
+        AND cr.ancestorid = c.id
+  )
+  -- calculate rootpost: when ancestor's id matches a post's id, then it is the root post
+, comments_with_rootpost AS (
+    SELECT c.id, c.ancestorid AS postid
+      FROM comments_with_rootpost_stage1 c
+         , posts p
+     WHERE 1=1
+       AND c.ancestorid = p.id
+)
+UPDATE comments_d c
+   SET postid = cr.postid
+  FROM comments_with_rootpost cr
+ WHERE c.id = cr.id
+;

--- a/solutions/SQLSolution/q1.sql
+++ b/solutions/SQLSolution/q1.sql
@@ -1,7 +1,22 @@
+WITH RECURSIVE
+  -- calculate ancestors of all comments
+  -- we don't care about filtering for rootposts, as it will be done in the last step
+  -- by joining with posts, i.e. "posts left join comments_with_ancestors"
+  comments_with_ancestors(id, ancestorid) AS (
+     SELECT c.id, c.parentid AS ancestorid
+       FROM comments c
+   UNION
+     SELECT cr.id, c.parentid AS ancestorid
+       FROM comments_with_ancestors cr
+          , comments c
+      WHERE 1=1
+         -- join
+        AND cr.ancestorid = c.id
+  )
 -- we assume that no user puts more than 1 like on a single comment
 select p.id, 10*count(distinct c.id) + count(l.userid) as score
   from posts p
-       left join comments c on (p.id = c.postid)
+       left join comments_with_ancestors c on (p.id = c.ancestorid)
        left join likes l on (c.id = l.commentid)
  where 1=1
  group by p.id, p.ts

--- a/solutions/SQLSolution/src-gen/queries/.gitignore
+++ b/solutions/SQLSolution/src-gen/queries/.gitignore
@@ -1,9 +1,0 @@
-/CommentComponentSize.java
-/Commented.java
-/Likes.java
-/MutuallyLikedComment.java
-/Task1.java
-/Task2.java
-/TransitiveFriendLikers.java
-/TransitivelyCommented.java
-/Ttc.java

--- a/solutions/SQLSolution/src/ttc2018/Query.java
+++ b/solutions/SQLSolution/src/ttc2018/Query.java
@@ -10,7 +10,9 @@ import java.sql.SQLException;
 
 public enum Query {
     Q1_BATCH(Paths.get("q1.sql")),
+    Q1_ROOTPOST_INIT(Paths.get("q1-rootpost-init.sql")),
     Q1_INIT(Paths.get("q1-init.sql")),
+    Q1_ROOTPOST_MAINTAIN(Paths.get("q1-rootpost-maintain.sql")),
     Q1_MAINTAIN(Paths.get("q1-maintain.sql")),
     Q1_RETRIEVE(Paths.get("q1-retrieve.sql")),
     Q2_BATCH(Paths.get("q2.sql")),

--- a/solutions/SQLSolution/src/ttc2018/SolutionQ1.java
+++ b/solutions/SQLSolution/src/ttc2018/SolutionQ1.java
@@ -15,7 +15,9 @@ public class SolutionQ1 extends Solution {
 	@Override
 	void prepareStatements() {
 		Connection conn = getDbConnection();
+		Query.Q1_ROOTPOST_INIT.prepareStatement(conn);
 		Query.Q1_INIT.prepareStatement(conn);
+		Query.Q1_ROOTPOST_MAINTAIN.prepareStatement(conn);
 		Query.Q1_MAINTAIN.prepareStatement(conn);
 		Query.Q1_RETRIEVE.prepareStatement(conn);
 
@@ -24,6 +26,7 @@ public class SolutionQ1 extends Solution {
 
 	@Override
 	public String Initial() {
+		runVoidQuery(Query.Q1_ROOTPOST_INIT);
 		runVoidQuery(Query.Q1_INIT);
 		String result = runReadQuery(Query.Q1_RETRIEVE);
 
@@ -34,6 +37,7 @@ public class SolutionQ1 extends Solution {
 	public String Update(ModelChangeSet changes) {
 		beforeUpdate(changes);
 
+		runVoidQuery(Query.Q1_ROOTPOST_MAINTAIN);
 		runVoidQuery(Query.Q1_MAINTAIN);
 		String result = runReadQuery(Query.Q1_RETRIEVE);
 
@@ -46,6 +50,7 @@ public class SolutionQ1 extends Solution {
 	public String Update(File changes) {
 		beforeUpdate(changes);
 
+		runVoidQuery(Query.Q1_ROOTPOST_MAINTAIN);
 		runVoidQuery(Query.Q1_MAINTAIN);
 		String result = runReadQuery(Query.Q1_RETRIEVE);
 

--- a/solutions/SQLSolution/src/ttc2018/sqlmodel/SqlTable.java
+++ b/solutions/SQLSolution/src/ttc2018/sqlmodel/SqlTable.java
@@ -9,6 +9,7 @@ public enum SqlTable {
     POSTS("posts"
             , new String[] {"id", "ts", "content", "submitterid"}),
     COMMENTS("comments"
+            // postid is omitted here as it is used and populated on the fly by the incremental Q1 query
             , new String[] {"id", "ts", "content", "submitterid", "parentid"}),
     USERS("users"
             , new String[] {"id", "name"}),

--- a/solutions/SQLSolution/src/ttc2018/sqlmodel/SqlTable.java
+++ b/solutions/SQLSolution/src/ttc2018/sqlmodel/SqlTable.java
@@ -9,7 +9,7 @@ public enum SqlTable {
     POSTS("posts"
             , new String[] {"id", "ts", "content", "submitterid"}),
     COMMENTS("comments"
-            , new String[] {"id", "ts", "content", "submitterid", "parentid", "postid"}),
+            , new String[] {"id", "ts", "content", "submitterid", "parentid"}),
     USERS("users"
             , new String[] {"id", "name"}),
     FRIENDS("friends"


### PR DESCRIPTION
SQL **Batch** solution for Q1 **computes the root post** for each comment **on the fly** in 2 steps:
- starting from all comments, using parallel traversal of the comments' parent links, all the ancestors are computed
- the ancestor that matches a post is the root.

Having the root post computed, scoring is done as before eliminating root post information from the input.

SQL **Incremental** solution for Q1 **materializes the root post** for each comment in the initial step and maintains that upon changesets received:
1. in the initial step, the root post is calculated as in the batch solution
2. in the maintenance step, starting from the new comments of the changeset, using parallel traversal of the comments' parent links, some ancestors are computed. If we reach a comment in the traversal whose root post is known from step (1) or previous step (2) runs, the traversal stops for that particular comment.

Having the root post materialized, scoring is done as before eliminating root post information from the input.
