### PR TITLE
Hawk: Move derived attribute computation into 'Initial' time

### DIFF
--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/AbstractLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/AbstractLauncher.java
@@ -176,6 +176,7 @@ public abstract class AbstractLauncher {
 	protected void initialView(final StandaloneHawk hawk)
 			throws IOException, InvalidQueryException, QueryExecutionException {
 
+		registerDerivedAttribute(hawk);
 		final List<List<Object>> results = runQuery(hawk);
 		final String elementsString = formatResults(results);
 

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/BatchLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/BatchLauncher.java
@@ -89,12 +89,6 @@ public class BatchLauncher extends AbstractLauncher {
 	}
 
 	@Override
-	protected void initialization(StandaloneHawk hawk) throws Exception {
-		super.initialization(hawk);
-		registerDerivedAttribute(hawk);
-	}
-
-	@Override
 	protected void modelLoading(final StandaloneHawk hawk) throws Throwable {
 		hawk.requestFileIndex(new File(opts.getChangePath(), INITIAL_MODEL_FILENAME));
 		hawk.waitForSync();

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/IncrementalUpdateLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/IncrementalUpdateLauncher.java
@@ -46,12 +46,6 @@ public class IncrementalUpdateLauncher extends AbstractIncrementalUpdateLauncher
 		return (List<List<Object>>) hawk.eol(opts.getQuery().getDerivedQuery());
 	}
 
-	@Override
-	protected void initialization(StandaloneHawk hawk) throws Exception {
-		super.initialization(hawk);
-		registerDerivedAttribute(hawk);
-	}
-
 	public static void main(String[] args) {
 		Map<String, String> env = System.getenv();
 		try {

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/IncrementalUpdateQueryLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/IncrementalUpdateQueryLauncher.java
@@ -219,6 +219,11 @@ public class IncrementalUpdateQueryLauncher extends AbstractIncrementalUpdateLau
 		listener = new QueryUpdateListener();
 	}
 
+	@Override
+	protected void registerDerivedAttribute(StandaloneHawk hawk) throws IOException {
+		/* no derived attribute for IUQ */
+	}
+
 	public static void main(String[] args) {
 		Map<String, String> env = System.getenv();
 		try {


### PR DESCRIPTION
The derived attribute was being defined before the folder was added, meaning that the precomputation of the scores in Hawk and HawkIncUpdate solutions was being done in the 'Load' stage instead of the 'Initial' stage.

This commit moves that definition of the derived attributes and the derivation of the initial set of scores to the 'Initial' phase.