### PR TITLE
Add Hawk SQLite solution

### DIFF
--- a/config/config-docker-java8.json
+++ b/config/config-docker-java8.json
@@ -13,7 +13,10 @@
       "HawkIncUpdateQuery",
       "HawkNeo4J",
       "HawkNeo4JIncUpdate",
-      "HawkNeo4JIncUpdateQuery"
+      "HawkNeo4JIncUpdateQuery",
+      "HawkSQLite",
+      "HawkSQLiteIncUpdate",
+      "HawkSQLiteIncUpdateQuery"
   ],
   "ChangeSets": [
     "1", "2"

--- a/docker/Dockerfile-java8
+++ b/docker/Dockerfile-java8
@@ -29,6 +29,9 @@ COPY solutions/HawkIncUpdateQuery solutions/HawkIncUpdateQuery
 COPY solutions/HawkNeo4J solutions/HawkNeo4J
 COPY solutions/HawkNeo4JIncUpdate solutions/HawkNeo4JIncUpdate
 COPY solutions/HawkNeo4JIncUpdateQuery solutions/HawkNeo4JIncUpdateQuery
+COPY solutions/HawkSQLite solutions/HawkSQLite
+COPY solutions/HawkSQLiteIncUpdate solutions/HawkSQLiteIncUpdate
+COPY solutions/HawkSQLiteIncUpdateQuery solutions/HawkSQLiteIncUpdateQuery
 
 # config
 COPY config/config-docker-java8.json config/config.json

--- a/solutions/Hawk/build-hawk-neo4j.sh
+++ b/solutions/Hawk/build-hawk-neo4j.sh
@@ -3,7 +3,7 @@
 REPO=https://gitlab.eclipse.org/eclipse/hawk/hawk.git
 SHA=3d6945abdf043bb2779d8fc9fa4da6152dd11a29
 
-if ! test -d hawk || ! test "$(cd hawk && git rev-parse --sq HEAD)" != "$SHA" ; then
+if test ! -d hawk -o "$(cd hawk && git rev-parse --sq HEAD)" != "$SHA" ; then
   rm -rf hawk
   git clone "$REPO" hawk
   pushd hawk

--- a/solutions/Hawk/build-hawk-neo4j.sh
+++ b/solutions/Hawk/build-hawk-neo4j.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 REPO=https://gitlab.eclipse.org/eclipse/hawk/hawk.git
-SHA=575d2aaad351a0dffb3de41f60db62662b92d14c
+SHA=3d6945abdf043bb2779d8fc9fa4da6152dd11a29
 
 if ! test -d hawk || ! test "$(cd hawk && git rev-parse --sq HEAD)" != "$SHA" ; then
   rm -rf hawk

--- a/solutions/Hawk/org.hawk.ttc2018/launch.sh
+++ b/solutions/Hawk/org.hawk.ttc2018/launch.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-if [ "$#" != 3 ]; then
-  echo "Usage: $0 batch|incU|incUQ 1|2|4|...|1024 Q1|Q2"
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 batch|incU|incUQ 1|2|4|...|1024 Q1|Q2 args..."
   exit 1
 fi
 
 PROFILE="$1"
 CHANGE_SET="$2"
 QUERY="$3"
+shift 3
 
 export ChangePath=$(readlink -f "../../../models/$CHANGE_SET")
 export ChangeSet="$CHANGE_SET"
@@ -15,4 +16,4 @@ export Query="$QUERY"
 export RunIndex=0
 export Sequences=20
 
-mvn -quiet -P"$PROFILE" compile exec:exec
+mvn -quiet -P"$PROFILE" compile exec:exec "$@"

--- a/solutions/Hawk/org.hawk.ttc2018/pom.xml
+++ b/solutions/Hawk/org.hawk.ttc2018/pom.xml
@@ -140,6 +140,10 @@
       <id>ossrh-snapshots</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </repository>
+    <repository>
+      <id>gitlab-maven-sqlite</id>
+      <url>https://gitlab.com/api/v4/projects/26325704/packages/maven</url>
+    </repository>
   </repositories>
 
   <profiles>
@@ -150,8 +154,7 @@
       <id>greycat</id>
       <activation>
         <property>
-          <name>backend</name>
-          <value>!neo4j</value>
+          <name>!backend</name>
         </property>
       </activation>
       <properties>
@@ -182,6 +185,26 @@
           <groupId>${project.groupId}</groupId>
           <artifactId>org.eclipse.hawk.neo4j-v2</artifactId>
           <version>${hawk.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>sqlite</id>
+      <activation>
+        <property>
+          <name>backend</name>
+          <value>sqlite</value>
+        </property>
+      </activation>
+      <properties>
+        <hawk.dbClass>org.hawklabs.sqlite.SQLiteDatabase</hawk.dbClass>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.hawklabs</groupId>
+          <artifactId>sqlite</artifactId>
+          <version>2.2.0-SNAPSHOT</version>
         </dependency>
       </dependencies>
     </profile>

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/updaters/ChangeSequenceAwareUpdater.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/updaters/ChangeSequenceAwareUpdater.java
@@ -255,7 +255,7 @@ public class ChangeSequenceAwareUpdater extends GraphModelUpdater {
 
 		// Do a defensive copy - we are going to delete things
 		final List<IGraphEdge> edges = new ArrayList<>();
-		for (IGraphEdge edge : sourceNode.getEdgesWithType(name)) {
+		for (IGraphEdge edge : sourceNode.getOutgoingWithType(name)) {
 			edges.add(edge);
 		}
 		for (IGraphEdge edge : edges) {

--- a/solutions/HawkSQLite/solution.ini
+++ b/solutions/HawkSQLite/solution.ini
@@ -1,0 +1,7 @@
+[build]
+default=echo Built from Hawk
+skipTests=echo Built from Hawk
+
+[run]
+Q1=mvn -f ../Hawk/org.hawk.ttc2018/pom.xml -quiet -Pbatch -Dbackend=sqlite exec:exec
+Q2=mvn -f ../Hawk/org.hawk.ttc2018/pom.xml -quiet -Pbatch -Dbackend=sqlite exec:exec

--- a/solutions/HawkSQLiteIncUpdate/solution.ini
+++ b/solutions/HawkSQLiteIncUpdate/solution.ini
@@ -1,0 +1,7 @@
+[build]
+default=echo Built from Hawk
+skipTests=echo Built from Hawk
+
+[run]
+Q1=mvn -f ../Hawk/org.hawk.ttc2018/pom.xml -quiet -P incU -Dbackend=sqlite exec:exec
+Q2=mvn -f ../Hawk/org.hawk.ttc2018/pom.xml -quiet -P incU -Dbackend=sqlite exec:exec

--- a/solutions/HawkSQLiteIncUpdateQuery/solution.ini
+++ b/solutions/HawkSQLiteIncUpdateQuery/solution.ini
@@ -1,0 +1,7 @@
+[build]
+default=echo Built from Hawk
+skipTests=echo Built from Hawk
+
+[run]
+Q1=mvn -f ../Hawk/org.hawk.ttc2018/pom.xml -quiet -P incUQ -Dbackend=sqlite exec:exec
+Q2=mvn -f ../Hawk/org.hawk.ttc2018/pom.xml -quiet -P incUQ -Dbackend=sqlite exec:exec


### PR DESCRIPTION
This PR adds a set of solutions using a new SQLite-based backend for Hawk, available [here](https://gitlab.com/hawklabs/hawk-sqlite). At the very least, it's faster than the Neo4j backend in the Q1/Q2 queries for the smaller sizes (1/2) in my laptop:

| Query | Size | Greycat IUQ | Neo4j IUQ | SQLite IUQ |
| --- | --: | --: | --: | --: |
| Q1 | 1 | 8.43s | 13.8s | 2.56s |
| Q1 | 2 | 12.57s | 14.74s | 3.73s |
| Q2 | 1 | 8.57s | 13.78s | 2.54s |
| Q2 | 2 | 13.08s | 13.89s | 3.71s |

We'll see how it scales to bigger models :-). @marci543 could you make sure that we get separate lines for each backend in the graphs, for all three variants (batch/incU/incUQ)?

Edit: fixed link :-D. 