### PR TITLE
Hawk solutions: avoid catch-all block for exceptions in the main() methods

### DIFF
--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/BatchLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/BatchLauncher.java
@@ -101,13 +101,9 @@ public class BatchLauncher extends AbstractLauncher {
 		return (List<List<Object>>) hawk.eol(opts.getQuery().getDerivedQuery());
 	}
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws Throwable {
 		Map<String, String> env = System.getenv();
-		try {
-			new BatchLauncher(new LauncherOptions(env)).run();
-		} catch (Throwable e) {
-			LOGGER.error(e.getMessage(), e);
-		}
+		new BatchLauncher(new LauncherOptions(env)).run();
 	}
 
 	@Override

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/IncrementalUpdateLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/IncrementalUpdateLauncher.java
@@ -46,13 +46,9 @@ public class IncrementalUpdateLauncher extends AbstractIncrementalUpdateLauncher
 		return (List<List<Object>>) hawk.eol(opts.getQuery().getDerivedQuery());
 	}
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws Throwable {
 		Map<String, String> env = System.getenv();
-		try {
-			new IncrementalUpdateLauncher(new LauncherOptions(env)).run();
-		} catch (Throwable e) {
-			LOGGER.error(e.getMessage(), e);
-		}
+		new IncrementalUpdateLauncher(new LauncherOptions(env)).run();
 	}
 
 

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/IncrementalUpdateQueryLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/IncrementalUpdateQueryLauncher.java
@@ -224,13 +224,9 @@ public class IncrementalUpdateQueryLauncher extends AbstractIncrementalUpdateLau
 		/* no derived attribute for IUQ */
 	}
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws Throwable {
 		Map<String, String> env = System.getenv();
-		try {
-			new IncrementalUpdateQueryLauncher(new LauncherOptions(env)).run();
-		} catch (Throwable e) {
-			LOGGER.error(e.getMessage(), e);
-		}
+		new IncrementalUpdateQueryLauncher(new LauncherOptions(env)).run();
 	}
 
 	@Override


### PR DESCRIPTION
This MR is intended to avoid cases like #99, where the error message was hidden in the `hawk.log` file instead of letting the program crash with a non-zero status code and a proper error message.