### PR TITLE
Fail on timeout in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,7 @@ jobs:
           ./docker.sh --pull                  # pull available images
           ./docker.sh --build-if-not-fresh    # (re)build image if different than current commit
           docker/set-configs.sh               # copy generic settings from config.json to config-docker-*.json files
-          ./docker.sh -r --java-heap-size 6G  # run measurements
-                                              # limit the CPU cores if needed: --cpus 0-7
+          # run measurements
+          # limit the CPU cores if needed, e.g. : --cpus 0-7
+          ./docker.sh -r --java-heap-size 6G \
+                         --run-params "-mc --error-on-timeout"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,10 @@ jobs:
           docker/set-configs.sh               # copy generic settings from config.json to config-docker-*.json files
           # run measurements
           # limit the CPU cores if needed, e.g. : --cpus 0-7
-          ./docker.sh -r --java-heap-size 6G \
-                         --run-params "-mc --error-on-timeout"
+          # do not run batch Hawk variants on all sizes
+          sed -Ei '/"(Hawk|HawkNeo4J|HawkSQLite)"/d' config/config-docker-java8.json
+          RUN_DOCKER_SH=(./docker.sh -r --java-heap-size 6G --run-params "-mc --error-on-timeout")
+          "${RUN_DOCKER_SH[@]}"
+          # run batch Hawk variants only on small size
+          cp config/config-docker-java8-ci-Hawk-batch-variants.json config/config-docker-java8.json
+          "${RUN_DOCKER_SH[@]}" -t java8

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ One might fine tune the script for the following purposes:
 * `run.py -b` -- builds the projects
 * `run.py -b -s` -- builds the projects without testing
 * `run.py -m` -- run the benchmark without building
+* `run.py -m --error-on-timeout` -- run the benchmark and return non-zero exit code if timeout reached
 * `run.py -v` -- visualizes the results of the latest benchmark
 * `run.py -c` -- check results by comparing them to the reference output. The benchmark shall already been executed using `-m`.
 * `run.py -t` -- build the project and run tests (usually unit tests as defined for the given solution)

--- a/config/config-docker-java8-ci-Hawk-batch-variants.json
+++ b/config/config-docker-java8-ci-Hawk-batch-variants.json
@@ -1,0 +1,17 @@
+{
+  "Queries": [
+    "Q1",
+    "Q2"
+  ],
+  "Tools": [
+      "Hawk",
+      "HawkNeo4J",
+      "HawkSQLite"
+  ],
+  "ChangeSets": [
+    "1"
+  ],
+  "Sequences": 20,
+  "Runs": 1,
+  "Timeout": 60
+}

--- a/config/config.json
+++ b/config/config.json
@@ -9,5 +9,5 @@
   ],
   "Sequences": 20,
   "Runs": 1,
-  "Timeout": 60
+  "Timeout": 180
 }

--- a/docker.sh
+++ b/docker.sh
@@ -11,14 +11,15 @@ echo "Command: $0 $@"
 if [[ "$#" -eq 0 ]]; then
   echo Parameters:
   echo "  --pull"
-  echo "  -b|--build                # runs 'scripts/run.py -b --skip-tests' inside"
-  echo "  --build-if-not-fresh      # rebuild runnable image if it is based on different commit"
+  echo "  -b|--build                        # runs 'scripts/run.py -b --skip-tests' inside"
+  echo "  --build-if-not-fresh              # rebuild runnable image if it is based on different commit"
   echo "  -p|--push"
   echo "  -r|--run"
   echo
-  echo "  -t|--tags \"TAG1 TAG2 ...\" # list the tags using \`docker/ls-images.sh\`"
-  echo "  -h|--java-heap-size 6G    # run Java solutions with 6 GB of heap (default)"
-  echo "  -c|--cpus 0-7,15          # limit container to use the first 8 CPU cores and the 16th one"
+  echo "  -t|--tags \"TAG1 TAG2 ...\"         # list the tags using \`docker/ls-images.sh\`"
+  echo "  -h|--java-heap-size 6G            # run Java solutions with 6 GB of heap (default)"
+  echo "  -c|--cpus 0-7,15                  # limit container to use the first 8 CPU cores and the 16th one"
+  echo "  --run-params \"--measure --check\"  # parameters passed to scripts/run.py"
   exit
 fi
 
@@ -45,6 +46,7 @@ else
 fi
 
 DOCKER_PARAMS=()
+RUN_PARAMS="--measure --check"
 
 # process parameters
 # https://stackoverflow.com/a/33826763
@@ -59,6 +61,7 @@ while [[ "$#" -gt 0 ]]; do
         -t|--tags) TAGS="$2"; shift ;;
         -h|--java-heap-size) DOCKER_PARAMS+=("-e" "JAVA_HEAP_SIZE=$2"); shift ;;
         -c|--cpus) DOCKER_PARAMS+=("--cpuset-cpus=$2"); shift ;;
+        --run-params) RUN_PARAMS="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -133,6 +136,7 @@ if [[ $run ]]; then
     docker run --rm \
       -v "$HOST_OUTPUT_PATH":/ttc/output/output.csv \
       -v "$TOOL_DOCKER_CONFIG_PATH":/ttc/config/config.json \
+      -e "RUN_PARAMS=${RUN_PARAMS}" \
       "${DOCKER_PARAMS[@]}" \
       -i ${IFS# REMOVE LINE IN GITHUB ACTIONS} \
       -t \

--- a/docker/entrypoint-differential.sh
+++ b/docker/entrypoint-differential.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # run the benchmark
-/usr/bin/time -v scripts/run.py -mc
+/usr/bin/time -v bash -c 'eval scripts/run.py "${RUN_PARAMS}"'

--- a/docker/entrypoint-graphblas.sh
+++ b/docker/entrypoint-graphblas.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # run the benchmark
-/usr/bin/time -v scripts/run.py -mc
+/usr/bin/time -v bash -c 'eval scripts/run.py "${RUN_PARAMS}"'

--- a/docker/entrypoint-java11.sh
+++ b/docker/entrypoint-java11.sh
@@ -7,4 +7,4 @@ set -e
 ag 'Xm(s|x)[0-9]+G' -l0 | xargs -0 sed -i -r 's/Xm(s|x)[0-9]+G/Xm\1'$JAVA_HEAP_SIZE'/g'
 
 # run the benchmark
-/usr/bin/time -v scripts/run.py -mc
+/usr/bin/time -v bash -c 'eval scripts/run.py "${RUN_PARAMS}"'

--- a/docker/entrypoint-java8.sh
+++ b/docker/entrypoint-java8.sh
@@ -7,4 +7,4 @@ set -e
 ag 'Xm(s|x)[0-9]+G' -l0 | xargs -0 sed -i -r 's/Xm(s|x)[0-9]+G/Xm\1'$JAVA_HEAP_SIZE'/g'
 
 # run the benchmark
-/usr/bin/time -v scripts/run.py -mc
+/usr/bin/time -v bash -c 'eval scripts/run.py "${RUN_PARAMS}"'

--- a/docker/entrypoint-neo4j.sh
+++ b/docker/entrypoint-neo4j.sh
@@ -7,4 +7,4 @@ set -e
 ag 'Xm(s|x)[0-9]+G' -l0 | xargs -0 sed -i -r 's/Xm(s|x)[0-9]+G/Xm\1'$JAVA_HEAP_SIZE'/g'
 
 # run the benchmark
-/usr/bin/time -v scripts/run.py -mc
+/usr/bin/time -v bash -c 'eval scripts/run.py "${RUN_PARAMS}"'

--- a/docker/entrypoint-net31.sh
+++ b/docker/entrypoint-net31.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # run the benchmark
-/usr/bin/time -v scripts/run.py -mc
+/usr/bin/time -v bash -c 'eval scripts/run.py "${RUN_PARAMS}"'

--- a/docker/entrypoint-sql.sh
+++ b/docker/entrypoint-sql.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # run the benchmark
-/usr/bin/time -v scripts/run.py -mc
+/usr/bin/time -v bash -c 'eval scripts/run.py "${RUN_PARAMS}"'


### PR DESCRIPTION
This PR adds `--error-on-timeout` option to `scripts/run.py`. CI fails if a tool reaches timeout.

@bluezio
I separated the run of `HawkNeo4J` in CI and only run it on size 1 since size 2 would need more than 10 minutes.
Relevant commit: 81e6e7bdf0edb1f50b14d452097fea5d33acebaf