### PR TITLE
Fix Hawk race condition

### DIFF
--- a/solutions/Hawk/org.hawk.ttc2018/pom.xml
+++ b/solutions/Hawk/org.hawk.ttc2018/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <logback.version>1.2.3</logback.version>
     <hawk.version>2.2.0-SNAPSHOT</hawk.version>
     <epsilon.version>2.0.0</epsilon.version>

--- a/solutions/Hawk/org.hawk.ttc2018/pom.xml
+++ b/solutions/Hawk/org.hawk.ttc2018/pom.xml
@@ -225,6 +225,8 @@
               <arguments>
                 <argument>-Xmx6G</argument>
                 <argument>-Xms6G</argument>
+                <argument>-XX:+UseG1GC</argument>
+                <argument>-XX:+UseStringDeduplication</argument>
                 <argument>-classpath</argument>
                 <!-- automatically creates the classpath using all project dependencies,
                      also adding the project build directory -->

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/AbstractIncrementalUpdateLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/AbstractIncrementalUpdateLauncher.java
@@ -44,8 +44,10 @@ public abstract class AbstractIncrementalUpdateLauncher extends AbstractLauncher
 
 	@Override
 	protected void modelLoading(final StandaloneHawk hawk) throws Throwable {
-		localFolder = hawk.requestFolderIndex(opts.getChangePath(), filterByChangeSequenceLimit(0));
-		hawk.waitForSync();
+		hawk.performAndWaitForSync(() -> {
+			localFolder = hawk.requestFolderIndex(opts.getChangePath(), filterByChangeSequenceLimit(0));
+			return null;
+		});
 
 		// Need these for quickly finding by ID
 		final IModelIndexer indexer = hawk.getIndexer();

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/AbstractLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/AbstractLauncher.java
@@ -220,8 +220,7 @@ public abstract class AbstractLauncher {
 		final File fInitial = new File(changePath, INITIAL_MODEL_FILENAME);
 		applyChanges(fInitial, iChangeSequence, fChange);
 	
-		hawk.getIndexer().requestImmediateSync();
-		hawk.waitForSync();
+		hawk.performAndWaitForSync(() -> { hawk.getIndexer().requestImmediateSync(); return null; });
 	
 		final List<List<Object>> results = runQuery(hawk);
 		final String elementsString = formatResults(results);

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/AbstractLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/AbstractLauncher.java
@@ -97,7 +97,7 @@ public abstract class AbstractLauncher {
 			this.phase = phase;
 		}
 
-		public void close() throws IOException {
+		public void close() {
 			final long elapsedTime = System.nanoTime() - startNanos;
 			final long availableBytes = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 

--- a/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/BatchLauncher.java
+++ b/solutions/Hawk/org.hawk.ttc2018/src/org/hawk/ttc2018/BatchLauncher.java
@@ -90,8 +90,7 @@ public class BatchLauncher extends AbstractLauncher {
 
 	@Override
 	protected void modelLoading(final StandaloneHawk hawk) throws Throwable {
-		hawk.requestFileIndex(new File(opts.getChangePath(), INITIAL_MODEL_FILENAME));
-		hawk.waitForSync();
+		hawk.performAndWaitForSync(() -> hawk.requestFileIndex(new File(opts.getChangePath(), INITIAL_MODEL_FILENAME)));
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
This is a fix for the race condition in #102, according to the idea of swapping steps 1 and 2 mentioned there.

So far, a run using a locally-built Docker image on sizes 1 and 2 seems to be working fine now:

```
==================== Run: java8 ====================
-------------------- Run java8 --------------------
vvv Config vvv
{
  "Queries": [
    "Q1",
    "Q2"
  ],
  "Tools": [
      "Hawk", "HawkNeo4J", "HawkSQLite"
  ],
  "ChangeSets": [
    "1", "2"
  ],
  "Sequences": 20,
  "Runs": 5,
  "Timeout": 600
}
^^^ End: Config ^^^
Running benchmark with root directory /ttc
Running benchmark: tool = Hawk, change set = 1, query = Q1
Running benchmark: tool = Hawk, change set = 1, query = Q1
Running benchmark: tool = Hawk, change set = 1, query = Q1
Running benchmark: tool = Hawk, change set = 1, query = Q1
Running benchmark: tool = Hawk, change set = 1, query = Q1
Running benchmark: tool = Hawk, change set = 2, query = Q1
Running benchmark: tool = Hawk, change set = 2, query = Q1
Running benchmark: tool = Hawk, change set = 2, query = Q1
Running benchmark: tool = Hawk, change set = 2, query = Q1
Running benchmark: tool = Hawk, change set = 2, query = Q1
Running benchmark: tool = Hawk, change set = 1, query = Q2
Running benchmark: tool = Hawk, change set = 1, query = Q2
Running benchmark: tool = Hawk, change set = 1, query = Q2
Running benchmark: tool = Hawk, change set = 1, query = Q2
Running benchmark: tool = Hawk, change set = 1, query = Q2
Running benchmark: tool = Hawk, change set = 2, query = Q2
Running benchmark: tool = Hawk, change set = 2, query = Q2
Running benchmark: tool = Hawk, change set = 2, query = Q2
Running benchmark: tool = Hawk, change set = 2, query = Q2
Running benchmark: tool = Hawk, change set = 2, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q1
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 1, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q2
Running benchmark: tool = HawkNeo4J, change set = 2, query = Q2
Running benchmark: tool = HawkSQLite, change set = 1, query = Q1
Running benchmark: tool = HawkSQLite, change set = 1, query = Q1
Running benchmark: tool = HawkSQLite, change set = 1, query = Q1
Running benchmark: tool = HawkSQLite, change set = 1, query = Q1
Running benchmark: tool = HawkSQLite, change set = 1, query = Q1
Running benchmark: tool = HawkSQLite, change set = 2, query = Q1
Running benchmark: tool = HawkSQLite, change set = 2, query = Q1
Running benchmark: tool = HawkSQLite, change set = 2, query = Q1
Running benchmark: tool = HawkSQLite, change set = 2, query = Q1
Running benchmark: tool = HawkSQLite, change set = 2, query = Q1
Running benchmark: tool = HawkSQLite, change set = 1, query = Q2
Running benchmark: tool = HawkSQLite, change set = 1, query = Q2
Running benchmark: tool = HawkSQLite, change set = 1, query = Q2
Running benchmark: tool = HawkSQLite, change set = 1, query = Q2
Running benchmark: tool = HawkSQLite, change set = 1, query = Q2
Running benchmark: tool = HawkSQLite, change set = 2, query = Q2
Running benchmark: tool = HawkSQLite, change set = 2, query = Q2
Running benchmark: tool = HawkSQLite, change set = 2, query = Q2
Running benchmark: tool = HawkSQLite, change set = 2, query = Q2
Running benchmark: tool = HawkSQLite, change set = 2, query = Q2
	Command being timed: "bash -c eval scripts/run.py "${RUN_PARAMS}""
	User time (seconds): 4241.61
	System time (seconds): 265.63
	Percent of CPU this job got: 269%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 27:50.15
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 4292604
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 717
	Minor (reclaiming a frame) page faults: 39876373
	Voluntary context switches: 10319524
	Involuntary context switches: 2560678
	Swaps: 0
	File system inputs: 43352
	File system outputs: 13746408
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
^^^^^^^^^^^^^^^^^^^^ End: Run java8 ^^^^^^^^^^^^^^^^^^^^
```

Fixes #102 