### PR TITLE
YAMTL Q2: remove traces of explicit incrementality

### DIFF
--- a/solutions/EMFSolutionYAMTL/src/main/java/ttc2018/SolutionQ2.xtend
+++ b/solutions/EMFSolutionYAMTL/src/main/java/ttc2018/SolutionQ2.xtend
@@ -2,10 +2,7 @@ package ttc2018;
 
 import Changes.ModelChange
 import Changes.ModelChangeSet
-import SocialNetwork.Comment
-import java.util.HashMap
 import org.eclipse.emf.common.util.EList
-import ttc2018.yamtl.FriendComponentUtil_UF
 import ttc2018.yamtl.Q2_yamtl
 import yamtl.core.YAMTLModule.ExecutionMode
 import yamtl.core.YAMTLModule.ExecutionPhase
@@ -21,7 +18,6 @@ class SolutionQ2 extends Solution {
 	}
 
 	override String Initial() {
-		(xform as Q2_yamtl).componentList = new HashMap<Comment,FriendComponentUtil_UF>(xform.initialSizeFactor)
 		xform.execute()
 		(xform as Q2_yamtl).bestThree.map[id].join('|')
 	}

--- a/solutions/EMFSolutionYAMTL/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
+++ b/solutions/EMFSolutionYAMTL/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
@@ -4,7 +4,6 @@ import SocialNetwork.Comment
 import SocialNetwork.SocialNetworkPackage
 import SocialNetwork.Submission
 import java.util.List
-import java.util.Map
 import org.eclipse.xtend.lib.annotations.Accessors
 import yamtl.core.YAMTLModule
 
@@ -22,9 +21,6 @@ class Q2_yamtl extends YAMTLModule {
 	@Accessors
 	val List<Submission> candidatesWithNilScore = newArrayList
 
-	@Accessors
-	var Map<Comment,FriendComponentUtil_UF> componentList
-	
 	new () {
 		header().in('sn', SN).out('out', SN)
 		ruleStore( newArrayList(
@@ -35,12 +31,10 @@ class Q2_yamtl extends YAMTLModule {
 						var score = 0
 						var matches = false
 						
-						if (comment.likedBy !== null && comment.likedBy.size > 0) {
-							var fc = componentList.get(comment)
-							fc = new FriendComponentUtil_UF(comment.likedBy)
+						if (comment.likedBy.size > 0) {
+							val fc = new FriendComponentUtil_UF(comment.likedBy)
 							score = fc.score
 							threeBestCandidates.addIfIsThreeBest(comment, score)
-							componentList.put(comment, fc)
 							matches = true
 						} else {
 							if (threeBestCandidates.size <= 3)
@@ -57,3 +51,5 @@ class Q2_yamtl extends YAMTLModule {
 		threeBestCandidates.getBestThree(candidatesWithNilScore)
 	}
 }
+
+

--- a/solutions/EMFSolutionYAMTL_batch/src/main/java/ttc2018/SolutionQ2.xtend
+++ b/solutions/EMFSolutionYAMTL_batch/src/main/java/ttc2018/SolutionQ2.xtend
@@ -2,12 +2,8 @@ package ttc2018;
 
 import Changes.ModelChange
 import Changes.ModelChangeSet
-import SocialNetwork.Comment
-import java.util.HashMap
 import org.eclipse.emf.common.util.EList
-import ttc2018.yamtl.FriendComponentUtil_UF
 import ttc2018.yamtl.Q2_yamtl
-import yamtl.core.YAMTLModule.ExecutionMode
 import yamtl.core.YAMTLModule.ExecutionPhase
 
 class SolutionQ2 extends Solution {
@@ -20,7 +16,6 @@ class SolutionQ2 extends Solution {
 	}
 
 	override String Initial() {
-		(xform as Q2_yamtl).componentList = new HashMap<Comment,FriendComponentUtil_UF>(xform.initialSizeFactor)
 		xform.execute()
 		(xform as Q2_yamtl).bestThree.map[id].join('|')
 	}

--- a/solutions/EMFSolutionYAMTL_batch/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
+++ b/solutions/EMFSolutionYAMTL_batch/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
@@ -22,9 +22,6 @@ class Q2_yamtl extends YAMTLModule {
 	@Accessors
 	val List<Submission> candidatesWithNilScore = newArrayList
 
-	@Accessors
-	var Map<Comment,FriendComponentUtil_UF> componentList
-	
 	new () {
 		header().in('sn', SN).out('out', SN)
 		ruleStore( newArrayList(
@@ -35,12 +32,10 @@ class Q2_yamtl extends YAMTLModule {
 						var score = 0
 						var matches = false
 						
-						if (comment.likedBy !== null && comment.likedBy.size > 0) {
-							var fc = componentList.get(comment)
-							fc = new FriendComponentUtil_UF(comment.likedBy)
+						if (comment.likedBy.size > 0) {
+							val fc = new FriendComponentUtil_UF(comment.likedBy)
 							score = fc.score
 							threeBestCandidates.addIfIsThreeBest(comment, score)
-							componentList.put(comment, fc)
 							matches = true
 						} else {
 							if (threeBestCandidates.size <= 3)
@@ -57,3 +52,5 @@ class Q2_yamtl extends YAMTLModule {
 		threeBestCandidates.getBestThree(candidatesWithNilScore)
 	}
 }
+
+

--- a/solutions/EMFSolutionYAMTL_expl/src/main/java/ttc2018/SolutionQ2.xtend
+++ b/solutions/EMFSolutionYAMTL_expl/src/main/java/ttc2018/SolutionQ2.xtend
@@ -23,7 +23,7 @@ class SolutionQ2 extends Solution {
 	}
 
 	override String Initial() {
-		(xform as Q2_yamtl).componentList = new HashMap<Comment,FriendComponentUtil_UF>(xform.initialSizeFactor)
+		(xform as Q2_yamtl).componentMap = new HashMap<Comment,FriendComponentUtil_UF>(xform.initialSizeFactor)
 		xform.execute()
 		(xform as Q2_yamtl).bestThree.map[id].join('|')
 	}

--- a/solutions/EMFSolutionYAMTL_expl/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
+++ b/solutions/EMFSolutionYAMTL_expl/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
@@ -42,10 +42,7 @@ class Q2_yamtl extends YAMTLModule {
 							var fc = componentMap.get(comment)
 							if (fc===null) {
 								fc = new FriendComponentUtil_UF(comment.likedBy)
-								score = fc.score
-								threeBestCandidates.addIfIsThreeBest(comment, score)
 								componentMap.put(comment, fc)
-								matches = true
 							} else {
 								val map = this.fetch('dirtyFeatures') as Map<EObject,List<YAMTLFeatureValueChange>>
 								for (e: map.entrySet) {
@@ -56,9 +53,10 @@ class Q2_yamtl extends YAMTLModule {
 										}
 									}
 								}
-								score = fc.score
-								threeBestCandidates.addIfIsThreeBest(comment, score)
 							}
+							score = fc.score
+							threeBestCandidates.addIfIsThreeBest(comment, score)
+							matches = true
 						} else {
 							if (threeBestCandidates.size <= 3)
 								candidatesWithNilScore.add(comment)

--- a/solutions/EMFSolutionYAMTL_expl/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
+++ b/solutions/EMFSolutionYAMTL_expl/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
@@ -26,7 +26,7 @@ class Q2_yamtl extends YAMTLModule {
 	val List<Submission> candidatesWithNilScore = newArrayList
 
 	@Accessors
-	var Map<Comment,FriendComponentUtil_UF> componentList
+	var Map<Comment,FriendComponentUtil_UF> componentMap
 	
 	new () {
 		header().in('sn', SN).out('out', SN)
@@ -39,12 +39,12 @@ class Q2_yamtl extends YAMTLModule {
 						var matches = false
 						
 						if (comment.likedBy.size > 0) {
-							var fc = componentList.get(comment)
+							var fc = componentMap.get(comment)
 							if (fc===null) {
 								fc = new FriendComponentUtil_UF(comment.likedBy)
 								score = fc.score
 								threeBestCandidates.addIfIsThreeBest(comment, score)
-								componentList.put(comment, fc)
+								componentMap.put(comment, fc)
 								matches = true
 							} else {
 								val map = this.fetch('dirtyFeatures') as Map<EObject,List<YAMTLFeatureValueChange>>

--- a/solutions/EMFSolutionYAMTL_expl/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
+++ b/solutions/EMFSolutionYAMTL_expl/src/main/java/ttc2018/yamtl/Q2_yamtl.xtend
@@ -38,7 +38,7 @@ class Q2_yamtl extends YAMTLModule {
 						var score = 0
 						var matches = false
 						
-						if (comment.likedBy !== null && comment.likedBy.size > 0) {
+						if (comment.likedBy.size > 0) {
 							var fc = componentList.get(comment)
 							if (fc===null) {
 								fc = new FriendComponentUtil_UF(comment.likedBy)


### PR DESCRIPTION
There were traces of logic that handles incrementality explicitly in the other variants (batch and implicit incremental). This skips an access to a map and storing scores for all comments during the initial phase.